### PR TITLE
Adding exclude handler to make hug happy.

### DIFF
--- a/hug_sentry/sentry_handler.py
+++ b/hug_sentry/sentry_handler.py
@@ -1,4 +1,6 @@
 class SentryExceptionHandler:
+    exclude = None
+
     def __init__(self, client):
         self.client = client
 

--- a/hug_sentry/sentry_handler.py
+++ b/hug_sentry/sentry_handler.py
@@ -1,5 +1,5 @@
 class SentryExceptionHandler:
-    exclude = None
+    exclude = type(None)
 
     def __init__(self, client):
         self.client = client


### PR DESCRIPTION
Didn't quite make this clear, HUG does an isinstance check to verify if the exception type being passed in is an exception type that should be ignored or not. The SentryExceptionHandler class is missing this exclude class var, so it crashes on a failed token authentication.