### PR TITLE
Fix handler for routes with url parameters

### DIFF
--- a/hug_sentry/sentry_handler.py
+++ b/hug_sentry/sentry_handler.py
@@ -4,7 +4,7 @@ class SentryExceptionHandler:
     def __init__(self, client):
         self.client = client
 
-    def __call__(self, request, response, exception):
+    def __call__(self, request, response, exception, **xargs):
         data = {
             'request': {
                 'url': request.url,

--- a/tests/app.py
+++ b/tests/app.py
@@ -4,3 +4,8 @@ import hug
 @hug.get('/fail')
 def fail(request, amount: hug.types.number):
     amount / 0
+
+
+@hug.get('/routing_fail/{amount}')
+def routing_fail(request, amount: hug.types.number):
+    raise Exception("Oh no!")

--- a/tests/test_sentry_handler.py
+++ b/tests/test_sentry_handler.py
@@ -1,4 +1,4 @@
-import app
+from . import app
 import hug
 from hug_sentry import SentryExceptionHandler
 from unittest.mock import Mock
@@ -20,6 +20,22 @@ def test_sentry_handler():
     assert 'request' in data
     assert data['request']['method'] == 'GET'
     assert data['request']['query_string'] == 'amount=2'
+
+
+def test_sentry_handler_with_routing_parameters():
+    client = Mock()
+    handler = SentryExceptionHandler(client)
+    app.__hug__.http.add_exception_handler(Exception, handler)
+
+    with pytest.raises(Exception):
+        hug.test.get(app, 'routing_fail/' + str(2))
+
+    assert client.captureException.called
+
+    data = client.captureException.call_args[1]['data']
+    assert 'user' in data
+    assert 'request' in data
+    assert data['request']['method'] == 'GET'
 
 
 def test_clean_environment():


### PR DESCRIPTION
Check first commit for test that fails. Basically I found that if I have a function like:
```
@hug.get('/routing_fail/{amount}')
def routing_fail(request, amount: hug.types.number):
    raise Exception("Oh no!")
```

I would get an error like following when hug tries to call the handler in this package.
```
E           TypeError: __call__() got an unexpected keyword argument 'amount'
```

Simple fix is to add `**xargs` to the method signature
```
def __call__(self, request, response, exception, **xargs):
```